### PR TITLE
Room name in dir names or filenames

### DIFF
--- a/BaseLive.py
+++ b/BaseLive.py
@@ -60,7 +60,7 @@ class BaseLive(metaclass=abc.ABCMeta):
         room_info = self.get_room_info()
         if room_info['status']:
             logging.info(self.generate_log(
-                "直播间标题："+room_info['roomname']))
+                "直播间标题："+room_info['room_name']))
             return True
         else:
             logging.info(self.generate_log("等待开播"))

--- a/BiliLive.py
+++ b/BiliLive.py
@@ -13,6 +13,8 @@ class BiliLive(BaseLive):
         self.room_id = config.get('spec', {}).get('room_id', '')
         self.site_name = 'BiliBili'
         self.site_domain = 'live.bilibili.com'
+        # 放在这里保证一次不断流的直播会一直用最初的直播间名
+        self.room_name = self.get_room_info()['room_name']
 
     def get_room_info(self) -> dict:
         data = {}
@@ -23,7 +25,7 @@ class BiliLive(BaseLive):
         }).json()
         logging.debug(self.generate_log("房间API消息："+response['msg']))
         if response['msg'] == 'ok':
-            data['roomname'] = response['data']['title']
+            data['room_name'] = response['data']['title']
             data['site_name'] = self.site_name
             data['site_domain'] = self.site_domain
             data['status'] = response['data']['live_status'] == 1

--- a/BiliLive.py
+++ b/BiliLive.py
@@ -14,7 +14,8 @@ class BiliLive(BaseLive):
         self.site_name = 'BiliBili'
         self.site_domain = 'live.bilibili.com'
         # 放在这里保证一次不断流的直播会一直用最初的直播间名
-        self.room_name = self.get_room_info()['room_name']
+        self.room_name = self.get_room_info()['room_name'] if config.get(
+            'root', {}).get('room_name_in_naming', False) else ""
 
     def get_room_info(self) -> dict:
         data = {}

--- a/BiliLiveRecorder.py
+++ b/BiliLiveRecorder.py
@@ -17,7 +17,7 @@ class BiliLiveRecorder(BiliLive):
     def __init__(self, config: dict, global_start: datetime.datetime):
         BiliLive.__init__(self, config)
         self.record_dir = utils.init_record_dir(
-            self.room_id, global_start, config.get('root', {}).get('data_path', "./"))
+            self.room_id, global_start, self.room_name, config.get('root', {}).get('data_path', "./"))
 
     def record(self, record_url: str, output_filename: str) -> None:
         try:
@@ -52,7 +52,8 @@ class BiliLiveRecorder(BiliLive):
             try:
                 if self.live_status:
                     urls = self.get_live_urls()
-                    filename = utils.generate_filename(self.room_id)
+                    filename = utils.generate_video_filename(
+                        self.room_id, self.room_name)
                     c_filename = os.path.join(self.record_dir, filename)
                     self.record(urls[0], c_filename)
                     logging.info(self.generate_log('录制完成' + c_filename))

--- a/DanmuRecorder.py
+++ b/DanmuRecorder.py
@@ -16,7 +16,8 @@ class BiliDanmuRecorder(BiliLive):
     def __init__(self, config: dict, global_start: datetime.datetime):
         BiliLive.__init__(self, config)
         self.room_server_api = 'wss://broadcastlv.chat.bilibili.com/sub'
-        self.danmu_dir = utils.init_danmu_log_dir(self.room_id,global_start,config.get('root',{}).get('data_path',"./"))
+        self.danmu_dir = utils.init_danmu_log_dir(
+            self.room_id, global_start, self.room_name, config.get('root', {}).get('data_path', "./"))
 
     async def __send_heart_beat(self, websocket):
         hb = '00000010001000010000000200000001'

--- a/Processor.py
+++ b/Processor.py
@@ -132,6 +132,7 @@ class Processor(BiliLive):
     def pre_concat(self) -> None:
         filelist = os.listdir(self.record_dir)
         with open(self.merge_conf_path, "w", encoding="utf-8") as f:
+            ts_path_list = []
             for filename in filelist:
                 if os.path.splitext(
                         os.path.join(self.record_dir, filename))[1] == ".flv" and os.path.getsize(os.path.join(self.record_dir, filename)) > 1024*1024:
@@ -146,8 +147,11 @@ class Processor(BiliLive):
                                      'format']['duration'])
                     start_time = get_start_time(filename)
                     self.times.append((start_time, duration))
-                    f.write(
-                        f"file '{os.path.abspath(ts_path)}'\n")
+                    ts_path_list.append(os.path.abspath(ts_path))
+            ts_path_list.sort()
+            for full_ts_path in ts_path_list:
+                f.write(
+                    f"file '{full_ts_path}'\n")
         _ = concat(self.merge_conf_path, self.merged_file_path,
                    self.ffmpeg_logfile_hander)
         self.times.sort(key=lambda x: x[0])

--- a/Processor.py
+++ b/Processor.py
@@ -107,14 +107,15 @@ class Processor(BiliLive):
         self.danmu_path = danmu_path
         self.global_start = utils.get_global_start_from_records(
             self.record_dir)
+        self.room_name = utils.get_room_name_from_records(self.record_dir)
         self.merge_conf_path = utils.get_merge_conf_path(
-            self.room_id, self.global_start, config.get('root', {}).get('data_path', "./"))
+            self.room_id, self.global_start, self.room_name, config.get('root', {}).get('data_path', "./"))
         self.merged_file_path = utils.get_mergd_filename(
-            self.room_id, self.global_start, config.get('root', {}).get('data_path', "./"))
+            self.room_id, self.global_start, self.room_name, config.get('root', {}).get('data_path', "./"))
         self.outputs_dir = utils.init_outputs_dir(
-            self.room_id, self.global_start, config.get('root', {}).get('data_path', "./"))
+            self.room_id, self.global_start, self.room_name, config.get('root', {}).get('data_path', "./"))
         self.splits_dir = utils.init_splits_dir(
-            self.room_id, self.global_start, self.config.get('root', {}).get('data_path', "./"))
+            self.room_id, self.global_start, self.room_name, self.config.get('root', {}).get('data_path', "./"))
         self.times = []
         self.live_start = self.global_start
         self.live_duration = 0

--- a/Processor.py
+++ b/Processor.py
@@ -107,7 +107,8 @@ class Processor(BiliLive):
         self.danmu_path = danmu_path
         self.global_start = utils.get_global_start_from_records(
             self.record_dir)
-        self.room_name = utils.get_room_name_from_records(self.record_dir)
+        self.room_name = utils.get_room_name_from_records(self.record_dir) if config.get(
+            'root', {}).get('room_name_in_naming', False) else ""
         self.merge_conf_path = utils.get_merge_conf_path(
             self.room_id, self.global_start, self.room_name, config.get('root', {}).get('data_path', "./"))
         self.merged_file_path = utils.get_mergd_filename(

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ FortuneDayssss/BilibiliUploader
 - check_interval: 直播间开播状态检查间隔，单位为秒，每个监控直播间单独计数，因此如果监控直播间较多，建议适当调大。由于B站API访问次数限制，建议不要小于30。默认：100
 - print_interval：控制台消息打印间隔，单位为秒。
 - data_path: 数据文件路径。默认："./"（即程序所在路径）
+- room_name_in_naming: 是否在生成的文件、文件夹名中带上开播时的直播间名称。默认：False
 - logger: 日志相关设置
   - log_path: 日志文件路径。默认："./log"
   - log_level: 日志级别，可选DEBUG\INFO\WARN

--- a/utils.py
+++ b/utils.py
@@ -49,7 +49,7 @@ def init_data_dirs(root_dir: str = os.getcwd()) -> None:
 def generate_general_path_base(room_id: str, timestamp: datetime.datetime, room_name: str = "") -> str:
     # TODO: 该替换操作不可逆。可以考虑生成一个metadata文件用于保留（包括直播间名称在内的）各种元信息
     filename_safe_room_name = room_name.translate(
-        "".maketrans("_\/|:&?<>\"", "-------()'"))
+        "".maketrans("_\/|:&?<>\"", "---------'"))
     timestamp_str = timestamp.strftime('%Y-%m-%d_%H-%M-%S')
     return "_".join(filter(None, [room_id, timestamp_str, filename_safe_room_name]))
 

--- a/utils.py
+++ b/utils.py
@@ -79,7 +79,7 @@ def get_global_start_from_records(record_dir: str) -> datetime.datetime:
 
 def get_room_name_from_records(record_dir: str) -> str:
     base = os.path.basename(record_dir)
-    return base.split("_")[4]
+    return base.split("_")[3]
 
 
 def get_mergd_filename(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:

--- a/utils.py
+++ b/utils.py
@@ -46,22 +46,30 @@ def init_data_dirs(root_dir: str = os.getcwd()) -> None:
     check_and_create_dir(os.path.join(root_dir, 'data', 'splits'))
 
 
-def init_record_dir(room_id: str, global_start: datetime.datetime, root_dir: str = os.getcwd()) -> str:
+def generate_general_path_base(room_id: str, timestamp: datetime.datetime, room_name: str = "") -> str:
+    # TODO: 该替换操作不可逆。可以考虑生成一个metadata文件用于保留（包括直播间名称在内的）各种元信息
+    filename_safe_room_name = room_name.translate(
+        "".maketrans("_\/|:&?<>\"", "-------()'"))
+    timestamp_str = timestamp.strftime('%Y-%m-%d_%H-%M-%S')
+    return "_".join(filter(None, [room_id, timestamp_str, filename_safe_room_name]))
+
+
+def init_record_dir(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:
     dirs = os.path.join(root_dir, 'data', 'records',
-                        f"{room_id}_{global_start.strftime('%Y-%m-%d_%H-%M-%S')}")
+                        f"{generate_general_path_base(room_id, global_start, room_name)}")
     check_and_create_dir(dirs)
     return dirs
 
 
-def init_danmu_log_dir(room_id: str, global_start: datetime.datetime, root_dir: str = os.getcwd()) -> str:
+def init_danmu_log_dir(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:
     log_dir = os.path.join(
-        root_dir, 'data', 'danmu', f"{room_id}_{global_start.strftime('%Y-%m-%d_%H-%M-%S')}")
+        root_dir, 'data', 'danmu', f"{generate_general_path_base(room_id, global_start, room_name)}")
     check_and_create_dir(log_dir)
     return log_dir
 
 
-def generate_filename(room_id: str) -> str:
-    return f"{room_id}_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.flv"
+def generate_video_filename(room_id: str, room_name: str = "") -> str:
+    return f"{generate_general_path_base(room_id, datetime.datetime.now(), room_name)}.flv"
 
 
 def get_global_start_from_records(record_dir: str) -> datetime.datetime:
@@ -69,29 +77,34 @@ def get_global_start_from_records(record_dir: str) -> datetime.datetime:
     return datetime.datetime.strptime(" ".join(base.split("_")[1:3]), '%Y-%m-%d %H-%M-%S')
 
 
-def get_mergd_filename(room_id: str, global_start: datetime.datetime, root_dir: str = os.getcwd()) -> str:
+def get_room_name_from_records(record_dir: str) -> str:
+    base = os.path.basename(record_dir)
+    return base.split("_")[4]
+
+
+def get_mergd_filename(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:
     filename = os.path.join(root_dir, 'data', 'merged',
-                            f"{room_id}_{global_start.strftime('%Y-%m-%d_%H-%M-%S')}_merged.mp4")
+                            f"{generate_general_path_base(room_id, global_start, room_name)}_merged.mp4")
     return filename
 
 
-def init_outputs_dir(room_id: str, global_start: datetime.datetime, root_dir: str = os.getcwd()) -> str:
+def init_outputs_dir(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:
     dirs = os.path.join(root_dir, 'data', 'outputs',
-                        f"{room_id}_{global_start.strftime('%Y-%m-%d_%H-%M-%S')}")
+                        f"{generate_general_path_base(room_id, global_start, room_name)}")
     check_and_create_dir(dirs)
     return dirs
 
 
-def init_splits_dir(room_id: str, global_start: datetime.datetime, root_dir: str = os.getcwd()) -> str:
+def init_splits_dir(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:
     dirs = os.path.join(root_dir, 'data', 'splits',
-                        f"{room_id}_{global_start.strftime('%Y-%m-%d_%H-%M-%S')}")
+                        f"{generate_general_path_base(room_id, global_start, room_name)}")
     check_and_create_dir(dirs)
     return dirs
 
 
-def get_merge_conf_path(room_id: str, global_start: datetime.datetime, root_dir: str = os.getcwd()) -> str:
+def get_merge_conf_path(room_id: str, global_start: datetime.datetime, room_name: str = "", root_dir: str = os.getcwd()) -> str:
     filename = os.path.join(root_dir, 'data', 'merge_confs',
-                            f"{room_id}_{global_start.strftime('%Y-%m-%d_%H-%M-%S')}_merge_conf.txt")
+                            f"{generate_general_path_base(room_id, global_start, room_name)}_merge_conf.txt")
     return filename
 
 


### PR DESCRIPTION
For https://github.com/AsaChiri/DDRecorder/issues/15

* 在所有生成的文件、文件夹名称前缀中带上开播时的直播间名称
    * 文件、文件夹名前缀将形如： `{room_id}_{timestamp}_{room_name}` 以保证文件、文件夹仍可以用room id和时间戳排序
* 对可能存在的windows/macos/linux不允许用于文件名的特殊字符进行了替换
* 在config里加了一个新flag作为开关
* 对utils做了一点refactor

想要确认的点：
* 开关应该做成全局的还是每个直播间特定的？
* 当前实现对“直播中途更改直播间名称且断流”的情况是无法与“主观停止直播更改直播间名称并重新开启”或者“连续两场名称不同的直播”进行区分的。如果只是录播归档无所谓，不过对录播后自动投稿上传可能会造成不便？是否应该考虑增加一个判断机制？