### PR TITLE
Fix: add acodec

### DIFF
--- a/Processor.py
+++ b/Processor.py
@@ -84,7 +84,7 @@ def count(danmu_list: List, live_start: datetime.datetime, live_duration: float,
 
 def flv2ts(input_file: str, output_file: str, ffmpeg_logfile_hander) -> subprocess.CompletedProcess:
     ret = subprocess.run(
-        f"ffmpeg -y -fflags +discardcorrupt -i {input_file} -c copy -bsf:v h264_mp4toannexb -f mpegts {output_file}", shell=True, check=True, stdout=ffmpeg_logfile_hander)
+        f"ffmpeg -y -fflags +discardcorrupt -i {input_file} -c copy -bsf:v h264_mp4toannexb -acodec aac -f mpegts {output_file}", shell=True, check=True, stdout=ffmpeg_logfile_hander)
     return ret
 
 


### PR DESCRIPTION
有时候 flv 转 ts 会发生 `AAC bitstream not in ADTS format and extradata missing` 错误，转出来的 ts 中 audio stream 的采样率为 0，进而导致后面合并出错