### PR TITLE
Fix: fix live_status out of sync

### DIFF
--- a/BiliLiveRecorder.py
+++ b/BiliLiveRecorder.py
@@ -13,11 +13,14 @@ from BiliLive import BiliLive
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
-class BiliLiveRecorder(BiliLive):
-    def __init__(self, config: dict, global_start: datetime.datetime):
-        BiliLive.__init__(self, config)
+class BiliLiveRecorder:
+    def __init__(self, bl: BiliLive, global_start: datetime.datetime):
+        self.__bl = bl
         self.record_dir = utils.init_record_dir(
-            self.room_id, global_start, config.get('root', {}).get('data_path', "./"))
+            self.room_id, global_start, self.config.get('root', {}).get('data_path', "./"))
+
+    def __getattr__(self, name):
+        return object.__getattribute__(self.__bl, name)
 
     def record(self, record_url: str, output_filename: str) -> None:
         try:

--- a/DanmuRecorder.py
+++ b/DanmuRecorder.py
@@ -13,12 +13,15 @@ from BiliLive import BiliLive
 import brotli
 import struct
 
-class BiliDanmuRecorder(BiliLive):
-    def __init__(self, config: dict, global_start: datetime.datetime):
-        BiliLive.__init__(self, config)
+class BiliDanmuRecorder:
+    def __init__(self, bl: BiliLive, global_start: datetime.datetime):
+        self.__bl = bl
         self.conf = self.get_room_conf()
         self.room_server_api = f"wss://{self.conf['available_hosts'][0]['host']}:{self.conf['available_hosts'][0]['wss_port']}/sub"
-        self.danmu_dir = utils.init_danmu_log_dir(self.room_id,global_start,config['root']['data_path'])
+        self.danmu_dir = utils.init_danmu_log_dir(self.room_id,global_start,self.config['root']['data_path'])
+
+    def __getattr__(self, name):
+        return object.__getattribute__(self.__bl, name)
 
     def __pack(self,data: bytes, protocol_version: int, datapack_type: int):
         sendData = bytearray()

--- a/MainRunner.py
+++ b/MainRunner.py
@@ -66,8 +66,8 @@ class MainRunner():
             while True:
                 if not self.prev_live_status and self.bl.live_status:                 
                     start = datetime.datetime.now()
-                    self.blr = BiliLiveRecorder(self.config, start)
-                    self.bdr = BiliDanmuRecorder(self.config, start)
+                    self.blr = BiliLiveRecorder(self.bl, start)
+                    self.bdr = BiliDanmuRecorder(self.bl, start)
                     record_process = Process(
                         target=self.blr.run)
                     danmu_process = Process(


### PR DESCRIPTION
This is an attempt to #17

我发现不仅会产生空目录，而且 proc_process 会产生大量异常。这些异常不会影响录播，据我的观察，它们大量发生于一次录播结束的时候，原因是
https://github.com/AsaChiri/DDRecorder/blob/336cc831480620b49b01f819a1dd00ebf5e98f6e/MainRunner.py#L66-L94
当 record_process 和 danmu_process 退出后，外面的 self.bl.live_status 还没有到更新周期，所以状态还是在播，就会又开始一次录制。它会一直不停地开始录制直到 self.bl.live_status 自轮询更新为止。

尝试修复：通过代理模式继承 bl 的实例，这样内外的状态即是同步的

待测试