### PR TITLE
fix: live status shadowing

### DIFF
--- a/MainRunner.py
+++ b/MainRunner.py
@@ -98,8 +98,7 @@ class MainRunner():
                         self.config, self.blr.record_dir, self.bdr.danmu_dir, self.current_state, self.state_change_time))
                     proc_process.start()
                     try:
-                        self.bl.__live_status = self.bl.check_live_status()
-                        self.bl.__last_check_time = datetime.datetime.now()
+                        self.bl.check_live_status()
                     except Exception as e:
                         logging.error(
                             "Status Error"+str(e)+traceback.format_exc())


### PR DESCRIPTION
很尴尬就是，#46 其实并没有真正解决 #17，但是让问题显著变少了。以前会出来一大堆空目录，现在每次录播只会多出来一个。原因是我在初始化 `BiliLiveRecorder` 和 `BiliDanmuRecorder` 的时候挂载了 `MainRunner` 中 `self.bl` 的状态（上次检查的时间），这样子进程和父进程检查的时间相差变小了。并不是像我想象的那样，子进程对 self 中状态的修改能直接反馈给父进程。https://stackoverflow.com/a/40873071

#47 也没有解决 #17，但是思路应该是对的。问题是不能直接通过给派生类属性赋值操作基类的属性（见下面示例代码），这个 Pr 提供了修复。
```python
class BaseClass:
    def __init__(self):
        self.__live_status = False

    @property
    def live_status(self) -> bool:
        return self.__live_status

    @live_status.setter
    def live_status(self, status: bool):
        self.__live_status = status


class SubClass(BaseClass):
    def __init__(self):
        super().__init__()


x = SubClass()
x.__live_status = True
# False
print(x.live_status)
x.live_status = True
# True
print(x.live_status)
```
然后实际上，在这个 Pr 之前，
https://github.com/AsaChiri/DDRecorder/blob/1ca39f94ea46c3eed12bad730f38862d19c31764/BiliLive.py#L16
甚至是没有用的，因为它并没有“check_live_status”，只是更新了“room_info”，“room_info”在第一次访问“live_status”属性之前又没有用到。
https://github.com/AsaChiri/DDRecorder/blob/1ca39f94ea46c3eed12bad730f38862d19c31764/BaseLive.py#L59-L67
